### PR TITLE
fix(hooks): fix race conditions in hooks

### DIFF
--- a/snap/hooks/connect-plug-configuration-read
+++ b/snap/hooks/connect-plug-configuration-read
@@ -7,7 +7,7 @@ if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
     exit 1
 fi
 
-snapctl start --enable "${SNAP_NAME}".read-configuration 2>&1
+snapctl start --enable "${SNAP_NAME}.read-configuration" 2>&1
 
 "${SNAP}/usr/bin/try-enable-recording.sh"
 

--- a/snap/hooks/connect-plug-configuration-read
+++ b/snap/hooks/connect-plug-configuration-read
@@ -1,9 +1,9 @@
 #!/bin/sh -e
 
-CONFIGURATION_FILE_PATH=$SNAP_COMMON/configuration/ros2-data-exporter.yaml
+CONFIGURATION_FILE_PATH="${SNAP_COMMON}/configuration/ros2-data-exporter.yaml"
 
-if [ ! -f "$CONFIGURATION_FILE_PATH" ]; then
-    echo "Configuration file '$CONFIGURATION_FILE_PATH' does not exist."
+if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
+    echo "Configuration file '${CONFIGURATION_FILE_PATH}' does not exist."
     exit 1
 fi
 

--- a/snap/hooks/connect-plug-configuration-read
+++ b/snap/hooks/connect-plug-configuration-read
@@ -7,5 +7,8 @@ if [ ! -f "$CONFIGURATION_FILE_PATH" ]; then
     exit 1
 fi
 
-snapctl start --enable ${SNAP_NAME}.read-configuration 2>&1
-snapctl restart ${SNAP_NAME} 2>&1 || true
+snapctl start --enable "${SNAP_NAME}".read-configuration 2>&1
+
+"${SNAP}/usr/bin/try-enable-recording.sh"
+
+snapctl restart "${SNAP_NAME}" 2>&1 || true

--- a/snap/hooks/connect-plug-rob-cos-common-read
+++ b/snap/hooks/connect-plug-rob-cos-common-read
@@ -5,20 +5,4 @@ if snapctl services ${SNAP_NAME}.auto-clean | grep -q inactive; then
   snapctl start --enable ${SNAP_NAME}.auto-clean 2>&1 || true
 fi
 
-## if auto-clean started correctly we can start recording
-if snapctl services ${SNAP_NAME}.auto-clean | grep -q enabled; then
-  if snapctl services ${SNAP_NAME}.recorder | grep -q inactive; then
-    snapctl start --enable ${SNAP_NAME}.recorder 2>&1 || true
-  fi
-else
-  echo "auto-clean service not enabled - could not start recorder to avoid filling up disk"
-  exit 1
-fi
-
-if snapctl services ${SNAP_NAME}.synchronization | grep -q inactive; then
-  snapctl start --enable ${SNAP_NAME}.synchronization 2>&1 || true
-fi
-
-if snapctl services ${SNAP_NAME}.daily-rotation | grep -q inactive; then
-  snapctl start --enable ${SNAP_NAME}.daily-rotation 2>&1 || true
-fi
+$SNAP/usr/bin/try-enable-recording.sh

--- a/snap/hooks/connect-plug-rob-cos-common-read
+++ b/snap/hooks/connect-plug-rob-cos-common-read
@@ -1,8 +1,8 @@
 #!/bin/sh -e
 
 # now we can start the services
-if snapctl services ${SNAP_NAME}.auto-clean | grep -q inactive; then
-  snapctl start --enable ${SNAP_NAME}.auto-clean 2>&1 || true
+if snapctl services "${SNAP_NAME}.auto-clean" | grep -q inactive; then
+  snapctl start --enable "${SNAP_NAME}.auto-clean" 2>&1 || true
 fi
 
-$SNAP/usr/bin/try-enable-recording.sh
+"${SNAP}/usr/bin/try-enable-recording.sh"

--- a/snap/local/try-enable-recording.sh
+++ b/snap/local/try-enable-recording.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/bash -e
+
+if ! snapctl is-connected configuration-read; then
+	logger -t ${SNAP_NAME} "Cannot start recorder yet, missing required interface: configuration-read"
+	exit 0
+fi
+
+if ! snapctl is-connected rob-cos-common-read; then
+	logger -t ${SNAP_NAME} "Cannot start recorder yet, missing required interface: rob-cos-common-read"
+	exit 0
+fi
+
+## if auto-clean started correctly we can start recording
+if snapctl services ${SNAP_NAME}.auto-clean | grep -q enabled; then
+	if snapctl services ${SNAP_NAME}.recorder | grep -q inactive; then
+		snapctl start --enable ${SNAP_NAME}.recorder 2>&1 || true
+	fi
+else
+	echo "auto-clean service not enabled - could not start recorder to avoid filling up disk"
+	exit 1
+fi
+
+if snapctl services ${SNAP_NAME}.synchronization | grep -q inactive; then
+	snapctl start --enable ${SNAP_NAME}.synchronization 2>&1 || true
+fi
+
+if snapctl services ${SNAP_NAME}.daily-rotation | grep -q inactive; then
+	snapctl start --enable ${SNAP_NAME}.daily-rotation 2>&1 || true
+fi

--- a/snap/local/try-enable-recording.sh
+++ b/snap/local/try-enable-recording.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/bash -e
 
+if snapctl services "${SNAP_NAME}.auto-clean" | grep -q inactive; then
+	snapctl start --enable "${SNAP_NAME}.auto-clean" 2>&1 || true
+fi
+
 if ! snapctl is-connected configuration-read; then
 	logger -t ${SNAP_NAME} "Cannot start recorder yet, missing required interface: configuration-read"
 	exit 0

--- a/snap/local/try-enable-recording.sh
+++ b/snap/local/try-enable-recording.sh
@@ -5,29 +5,29 @@ if snapctl services "${SNAP_NAME}.auto-clean" | grep -q inactive; then
 fi
 
 if ! snapctl is-connected configuration-read; then
-	logger -t ${SNAP_NAME} "Cannot start recorder yet, missing required interface: configuration-read"
+	logger -t "${SNAP_NAME}" "Cannot start recorder yet, missing required interface: configuration-read"
 	exit 0
 fi
 
 if ! snapctl is-connected rob-cos-common-read; then
-	logger -t ${SNAP_NAME} "Cannot start recorder yet, missing required interface: rob-cos-common-read"
+	logger -t "${SNAP_NAME}" "Cannot start recorder yet, missing required interface: rob-cos-common-read"
 	exit 0
 fi
 
 ## if auto-clean started correctly we can start recording
-if snapctl services ${SNAP_NAME}.auto-clean | grep -q enabled; then
-	if snapctl services ${SNAP_NAME}.recorder | grep -q inactive; then
-		snapctl start --enable ${SNAP_NAME}.recorder 2>&1 || true
+if snapctl services "${SNAP_NAME}.auto-clean" | grep -q enabled; then
+	if snapctl services "${SNAP_NAME}.recorder" | grep -q inactive; then
+		snapctl start --enable "${SNAP_NAME}.recorder" 2>&1 || true
 	fi
 else
 	echo "auto-clean service not enabled - could not start recorder to avoid filling up disk"
 	exit 1
 fi
 
-if snapctl services ${SNAP_NAME}.synchronization | grep -q inactive; then
-	snapctl start --enable ${SNAP_NAME}.synchronization 2>&1 || true
+if snapctl services "${SNAP_NAME}.synchronization"| grep -q inactive; then
+	snapctl start --enable "${SNAP_NAME}.synchronization" 2>&1 || true
 fi
 
-if snapctl services ${SNAP_NAME}.daily-rotation | grep -q inactive; then
-	snapctl start --enable ${SNAP_NAME}.daily-rotation 2>&1 || true
+if snapctl services "${SNAP_NAME}.daily-rotation" | grep -q inactive; then
+	snapctl start --enable "${SNAP_NAME}.daily-rotation" 2>&1 || true
 fi


### PR DESCRIPTION
If the rob-cos-common-read was auto-connected before the configuration auto connection.
The hook was trying to start the recorder that had no default config