### PR TITLE
[hermes-agent] fix: call read-configuration script directly from connect hook

### DIFF
--- a/snap/hooks/connect-plug-configuration-read
+++ b/snap/hooks/connect-plug-configuration-read
@@ -7,7 +7,7 @@ if [ ! -f "${CONFIGURATION_FILE_PATH}" ]; then
     exit 1
 fi
 
-snapctl start --enable "${SNAP_NAME}.read-configuration" 2>&1
+"${SNAP}/usr/bin/read-configuration.sh"
 
 "${SNAP}/usr/bin/try-enable-recording.sh"
 

--- a/snap/hooks/connect-plug-configuration-read
+++ b/snap/hooks/connect-plug-configuration-read
@@ -9,6 +9,9 @@ fi
 
 "${SNAP}/usr/bin/read-configuration.sh"
 
+# Keep the oneshot app enabled for subsequent snap restarts/reconfigurations
+snapctl start --enable "${SNAP_NAME}.read-configuration" 2>&1 || true
+
 "${SNAP}/usr/bin/try-enable-recording.sh"
 
 snapctl restart "${SNAP_NAME}" 2>&1 || true

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -4,7 +4,6 @@
 snapctl set device-uid!
 snapctl set topic-regex!
 snapctl set topic-exclude!
-snapctl set config-ready=false
 
 # default parameters
 snapctl set remote-server-ip!

--- a/snap/local/read-configuration.sh
+++ b/snap/local/read-configuration.sh
@@ -2,8 +2,6 @@
 
 echo "Reading configuration yaml from configuration snap."
 
-snapctl set config-ready=false
-
 CONFIGURATION_FILE_PATH=$SNAP_COMMON/configuration/ros2-data-exporter.yaml
 
 if [ ! -f "$CONFIGURATION_FILE_PATH" ]; then
@@ -19,6 +17,5 @@ snapctl set remote-server-port="$(yq '(.remote-server-port // 2222)' $CONFIGURAT
 snapctl set storage-base-path="$(yq '(.storage-base-path // "/var/lib/caddy-fileserver/")' $CONFIGURATION_FILE_PATH)"
 snapctl set max-bag-duration="$(yq '(.max-bag-duration // 300)' $CONFIGURATION_FILE_PATH)"
 snapctl set max-bag-size="$(yq '(.max-bag-size // 250000000)' $CONFIGURATION_FILE_PATH)"
-snapctl set config-ready=true
 
 echo "Configuration read."

--- a/snap/local/try-enable-recording.sh
+++ b/snap/local/try-enable-recording.sh
@@ -14,11 +14,6 @@ if ! snapctl is-connected rob-cos-common-read; then
 	exit 0
 fi
 
-if [ "$(snapctl get config-ready)" != "true" ]; then
-	logger -t "${SNAP_NAME}" "Cannot start recorder yet, configuration not ready"
-	exit 0
-fi
-
 ## if auto-clean started correctly we can start recording
 if snapctl services "${SNAP_NAME}.auto-clean" | grep -q enabled; then
 	if snapctl services "${SNAP_NAME}.recorder" | grep -q inactive; then


### PR DESCRIPTION
[hermes-agent]

## Overview

This PR switches configuration loading to a synchronous path in the `connect-plug-configuration-read` hook, so recorder gating no longer depends on async service startup timing.

## Changes

### 1) Run configuration read script directly (blocking)
- `snap/hooks/connect-plug-configuration-read`
  - Replaced:
    - `snapctl start --enable "${SNAP_NAME}.read-configuration"`
  - With:
    - `"${SNAP}/usr/bin/read-configuration.sh"`

### 2) Remove temporary `config-ready` flag plumbing
- `snap/hooks/install`
- `snap/local/read-configuration.sh`
- `snap/local/try-enable-recording.sh`

The explicit `config-ready` key is no longer necessary because configuration load now completes before `try-enable-recording.sh` is evaluated in that hook path.

## Why

Using `snapctl start` for the oneshot app can introduce ordering/timing races. Running the script directly gives deterministic sequencing in the hook:
1. read config
2. evaluate recorder-start prerequisites
3. start services if ready

## Notes

- Existing safety behavior for auto-clean remains unchanged (hard-fail branch retained).
- Interface gating (`configuration-read`, `rob-cos-common-read`) remains unchanged.

